### PR TITLE
fix: Windows testing

### DIFF
--- a/train_data_creator/src/main/data_preprocessor.py
+++ b/train_data_creator/src/main/data_preprocessor.py
@@ -1,5 +1,6 @@
 import gzip
 import warnings
+import numpy as np
 import pandas as pd
 
 from train_data_creator.src.main.utilities import correct_order_vcf_notation, equalize_class, \
@@ -181,7 +182,7 @@ class ClinVar:
         # Mapping to Gold Stars values
         for key, value in stars.items():
             data.loc[data[data['review'] == key].index, 'review'] = value
-        data['review'] = data['review'].astype(int)
+        data['review'] = data['review'].astype(np.int64)
 
         # Droppin
         data.drop(data[data['review'] < 1].index, inplace=True)

--- a/train_data_creator/test/validators/test_input_validator.py
+++ b/train_data_creator/test/validators/test_input_validator.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from stat import S_IREAD
+import stat
 
 from train_data_creator.test import get_project_root_dir
 from train_data_creator.src.main.validators.input_validator import InputValidator
@@ -19,6 +19,10 @@ class TestInputValidator(unittest.TestCase):
         if cls.__DIRECTORY__ in os.listdir(get_project_root_dir()):
             os.removedirs(os.path.join(get_project_root_dir(), cls.__DIRECTORY__))
         if cls.__READONLY_DIRECTORY__ in os.listdir(get_project_root_dir()):
+            # Fix for Windows because you can't delete an readonly directory
+            os.chmod(
+                os.path.join(get_project_root_dir(), cls.__READONLY_DIRECTORY__), stat.S_IWRITE
+            )
             os.removedirs(os.path.join(get_project_root_dir(), cls.__READONLY_DIRECTORY__))
 
     def test_vkgl_corr(self):
@@ -65,7 +69,7 @@ class TestInputValidator(unittest.TestCase):
     def test_output_not_writable(self):
         output = os.path.join(get_project_root_dir(), self.__READONLY_DIRECTORY__)
         os.mkdir(os.path.join(output))
-        os.chmod(output, S_IREAD)
+        os.chmod(output, stat.S_IREAD)
         # Testing if an existing not writable directory raises OSError
         self.assertRaises(
             OSError,


### PR DESCRIPTION
- Fixed some bugs where errors would be raised in tests when using Windows.

- Not able to fix the `OSError not raised by validate_output` in test `test_input_validator.py:test_output_not_writable`, due to the nature of interactions between `os.chmod` and Windows. Supplying an `mode` argument to `os.makedirs()` is ignored. Updated the teardown so it should delete the made directory.

Closes #4