### PR TITLE
Hotfix for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 setup(
     name='capice-resources',
-    version='1.0.0-dev',
+    version='1.0.0.dev0',
+    packages=[],
     url='https://capice.molgeniscloud.org/',
     license='LGPL-3.0',
     author='Molgenis',


### PR DESCRIPTION
Closes #20 using a hotfix. Actual packages to include should be decided later on during robustness story (which might also include alterations to project structure)!

Also includes fix for version number shown in error message from #20 (as pip normalized this).