### PR TITLE
chore: Bump dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     ],
     python_requires='>=3.9.*',
     install_requires=[
-        'pandas==1.3.4',
-        'numpy==1.22.0',
+        'pandas==1.5.2',
+        'numpy==1.24.1',
         'matplotlib==3.5.1',
         'scikit-learn==1.0.2',
         'graphviz==0.19.1',


### PR DESCRIPTION
- Updated Numpy from 1.22.0 (CVE-2020-13091) to 1.24.1
- Updated Pandas from 1.3.4 (CVE-2021-41495) to 1.5.2

Ignore the FutureWarnings raised by pandas, this will be fixed in the comming refactoring.

Closes #42 