### PR TITLE
fix: ClinVar SYMBOL ID in export VCF ID column

### DIFF
--- a/src/molgenis/capice_resources/train_data_creator/data_parsers/clinvar.py
+++ b/src/molgenis/capice_resources/train_data_creator/data_parsers/clinvar.py
@@ -54,6 +54,10 @@ class ClinVarParser:
                 Performed inplace.
         """
         self._process_column(clinvar_frame, TrainDataCreatorEnums.GENE.value, 'GENEINFO=')
+        # For now, deleting the SYMBOL ID as VKGL does not yet export this
+        clinvar_frame[
+            TrainDataCreatorEnums.GENE.value
+        ] = clinvar_frame[TrainDataCreatorEnums.GENE.value].str.split(':', expand=True)[0]
 
     def _obtain_review(self, clinvar_frame: pd.DataFrame) -> None:
         """

--- a/src/molgenis/capice_resources/train_data_creator/data_parsers/clinvar.py
+++ b/src/molgenis/capice_resources/train_data_creator/data_parsers/clinvar.py
@@ -55,6 +55,10 @@ class ClinVarParser:
         """
         self._process_column(clinvar_frame, TrainDataCreatorEnums.GENE.value, 'GENEINFO=')
         # For now, deleting the SYMBOL ID as VKGL does not yet export this
+
+        # TODO: Please note that multiple SYMBOL per single entry are now discarded and
+        #  does require change in the (near) future for both train-data-creator and process-vep:
+        #  https://github.com/molgenis/capice-resources/issues/54
         clinvar_frame[
             TrainDataCreatorEnums.GENE.value
         ] = clinvar_frame[TrainDataCreatorEnums.GENE.value].str.split(':', expand=True)[0]

--- a/tests/capice_resources/train_data_creator/data_parsers/test_clinvar_parser.py
+++ b/tests/capice_resources/train_data_creator/data_parsers/test_clinvar_parser.py
@@ -22,11 +22,11 @@ class TestClinvarParser(unittest.TestCase):
         self.specific_testing_frame = pd.DataFrame(
             {
                 'INFO': [
-                    'FIRSTCOL=value1;CLNSIG=LP;GENEINFO=foo;'
+                    'FIRSTCOL=value1;CLNSIG=LP;GENEINFO=foo:69;'
                     'CLNREVSTAT=criteria_provided,_conflicting_interpretations;LASTCOL=value1',
-                    'FIRSTCOL=value2;CLNSIG=P;GENEINFO=bar;'
+                    'FIRSTCOL=value2;CLNSIG=P;GENEINFO=bar:42030;'
                     'CLNREVSTAT=reviewed_by_expert_panel;LASTCOL=value2',
-                    'FIRSTCOL=value3;CLNSIG=B;GENEINFO=baz;'
+                    'FIRSTCOL=value3;CLNSIG=B;GENEINFO=baz:6969420;'
                     'CLNREVSTAT=criteria_provided,_single_submitter;LASTCOL=value3'
                 ]
             }


### PR DESCRIPTION
## SOP

### Changed

- Fixed a bug that allowed the SYMBOL ID to be present within the "gene" section of the export VCF "ID" column.

## Important notes

-

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
