### PR TITLE
Fix for plot paths giving very long string (that doesn't always fit)

### DIFF
--- a/src/molgenis/capice_resources/compare_model_performance/plotter.py
+++ b/src/molgenis/capice_resources/compare_model_performance/plotter.py
@@ -108,10 +108,10 @@ class Plotter:
         if model_2_label_path is None:
             model_2_label_path = model_1_label_path
 
-        figure_supertitle = f'Model 1 scores: {model_1_score_path}\n' \
-                            f'Model 1 labels: {model_1_label_path}\n' \
-                            f'Model 2 scores: {model_2_score_path}\n' \
-                            f'Model 2 labels: {model_2_label_path}\n'
+        figure_supertitle = f'Model 1 scores: {os.path.basename(model_1_score_path)}\n' \
+                            f'Model 1 labels: {os.path.basename(model_1_label_path)}\n' \
+                            f'Model 2 scores: {os.path.basename(model_2_score_path)}\n' \
+                            f'Model 2 labels: {os.path.basename(model_2_label_path)}\n'
 
         self._set_size_supertitle_layout(
             self.fig_auc,


### PR DESCRIPTION
## SOP

### Changed
- Plots now only show filename without path.

## Important notes

-

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
