### PR TITLE
fix: Unsupported alt contigs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 setup(
     name='capice-resources',
-    version='5.0.0',
+    version='5.0.1',
     packages=find_namespace_packages('src', exclude=['tests']),
     package_dir={"": "src"},
     url='https://github.com/molgenis/capice-resources/',

--- a/src/molgenis/capice_resources/train_data_creator/data_parsers/clinvar.py
+++ b/src/molgenis/capice_resources/train_data_creator/data_parsers/clinvar.py
@@ -6,7 +6,8 @@ import pandas as pd
 from molgenis.capice_resources.core import VCFEnums
 from molgenis.capice_resources.utilities import add_dataset_source
 from molgenis.capice_resources.train_data_creator import TrainDataCreatorEnums
-from molgenis.capice_resources.train_data_creator.utilities import apply_binarized_label
+from molgenis.capice_resources.train_data_creator.utilities import apply_binarized_label, \
+    check_unsupported_contigs
 
 
 class ClinVarParser:
@@ -23,6 +24,8 @@ class ClinVarParser:
                 Fully parsed and processed ClinVar dataframe, adhering to all the standard
                 columns and equalized to VKGL.
         """
+        print('Parsing ClinVar')
+        check_unsupported_contigs(clinvar_frame, '#CHROM')
         self._obtain_class(clinvar_frame)
         self._obtain_gene(clinvar_frame)
         self._obtain_review(clinvar_frame)

--- a/src/molgenis/capice_resources/train_data_creator/data_parsers/vkgl.py
+++ b/src/molgenis/capice_resources/train_data_creator/data_parsers/vkgl.py
@@ -5,7 +5,7 @@ from molgenis.capice_resources.core import VCFEnums
 from molgenis.capice_resources.utilities import add_dataset_source
 from molgenis.capice_resources.train_data_creator import TrainDataCreatorEnums
 from molgenis.capice_resources.train_data_creator.utilities import correct_order_vcf_notation, \
-    apply_binarized_label
+    apply_binarized_label, check_unsupported_contigs
 
 
 class VKGLParser:
@@ -22,6 +22,8 @@ class VKGLParser:
                 Fully parsed and processed VKGL dataframe, adhering to all the standard
                 columns and equalized to ClinVar.
         """
+        print('Parsing VKGL')
+        check_unsupported_contigs(vkgl_frame, 'chromosome')
         self._correct_column_names(vkgl_frame)
         self._correct_support(vkgl_frame)
         correct_order_vcf_notation(vkgl_frame)

--- a/src/molgenis/capice_resources/train_data_creator/utilities.py
+++ b/src/molgenis/capice_resources/train_data_creator/utilities.py
@@ -18,6 +18,7 @@ def check_unsupported_contigs(loaded_dataset: pd.DataFrame, column_name: str) ->
         column_name:
             The column name to check upon.
     """
+    # Ensuring that the order is set to string so that any alt contigs do not get unnoticed.
     loaded_dataset['contigs'] = loaded_dataset[column_name].astype(str)
     loaded_dataset.loc[loaded_dataset[loaded_dataset['contigs'] == 'X'].index, 'contigs'] = '23'
     loaded_dataset.loc[loaded_dataset[loaded_dataset['contigs'] == 'Y'].index, 'contigs'] = '24'
@@ -40,7 +41,6 @@ def correct_order_vcf_notation(pseudo_vcf: pd.DataFrame) -> None:
             Please note that this ordering is performed inplace.
 
     """
-    # Ensuring that the order is set to string so that any alt contigs do not get unnoticed.
     pseudo_vcf['order'] = pseudo_vcf[VCFEnums.CHROM.vcf_name]
     pseudo_vcf.loc[pseudo_vcf[pseudo_vcf['order'] == 'X'].index, 'order'] = 23
     pseudo_vcf.loc[pseudo_vcf[pseudo_vcf['order'] == 'Y'].index, 'order'] = 24

--- a/src/molgenis/capice_resources/train_data_creator/utilities.py
+++ b/src/molgenis/capice_resources/train_data_creator/utilities.py
@@ -7,6 +7,29 @@ from molgenis.capice_resources.core import VCFEnums, ColumnEnums
 from molgenis.capice_resources.train_data_creator import TrainDataCreatorEnums
 
 
+def check_unsupported_contigs(loaded_dataset: pd.DataFrame, column_name: str) -> None:
+    """
+    Function to check a loaded VKGL and/or ClinVar dataframe "chromosome" column for alternative
+    contigs to 1-22, X, Y and MT. Performed inplace.
+
+    Args:
+        loaded_dataset:
+            The loaded in pandas.DataFrame of the VKGL or ClinVar dataset.
+        column_name:
+            The column name to check upon.
+    """
+    loaded_dataset['contigs'] = loaded_dataset[column_name].astype(str)
+    loaded_dataset.loc[loaded_dataset[loaded_dataset['contigs'] == 'X'].index, 'contigs'] = '23'
+    loaded_dataset.loc[loaded_dataset[loaded_dataset['contigs'] == 'Y'].index, 'contigs'] = '24'
+    loaded_dataset.loc[loaded_dataset[loaded_dataset['contigs'] == 'MT'].index, 'contigs'] = '25'
+    present_contigs = np.array(range(1, 26)).astype(str)
+    alt_contigs = loaded_dataset[~loaded_dataset['contigs'].isin(present_contigs)]
+    if alt_contigs.shape[0] > 0:
+        warnings.warn(f'Removing unsupported contig for {alt_contigs.shape[0]} variant(s).')
+        loaded_dataset.drop(index=alt_contigs.index, inplace=True)
+    loaded_dataset.drop(columns='contigs', inplace=True)
+
+
 def correct_order_vcf_notation(pseudo_vcf: pd.DataFrame) -> None:
     """
     Function to order a (pseudo) VCF on chromosome and position.
@@ -18,15 +41,10 @@ def correct_order_vcf_notation(pseudo_vcf: pd.DataFrame) -> None:
 
     """
     # Ensuring that the order is set to string so that any alt contigs do not get unnoticed.
-    pseudo_vcf['order'] = pseudo_vcf[VCFEnums.CHROM.vcf_name].astype(str)
-    pseudo_vcf.loc[pseudo_vcf[pseudo_vcf['order'] == 'X'].index, 'order'] = '23'
-    pseudo_vcf.loc[pseudo_vcf[pseudo_vcf['order'] == 'Y'].index, 'order'] = '24'
-    pseudo_vcf.loc[pseudo_vcf[pseudo_vcf['order'] == 'MT'].index, 'order'] = '25'
-    present_orders = np.array(range(1, 26)).astype(str)
-    alt_contigs = pseudo_vcf[~pseudo_vcf['order'].isin(present_orders)]
-    if alt_contigs.shape[0] > 0:
-        warnings.warn(f'Removing unsupported contig for {alt_contigs.shape[0]} variant(s).')
-        pseudo_vcf.drop(index=alt_contigs.index, inplace=True)
+    pseudo_vcf['order'] = pseudo_vcf[VCFEnums.CHROM.vcf_name]
+    pseudo_vcf.loc[pseudo_vcf[pseudo_vcf['order'] == 'X'].index, 'order'] = 23
+    pseudo_vcf.loc[pseudo_vcf[pseudo_vcf['order'] == 'Y'].index, 'order'] = 24
+    pseudo_vcf.loc[pseudo_vcf[pseudo_vcf['order'] == 'MT'].index, 'order'] = 25
     pseudo_vcf['order'] = pseudo_vcf['order'].astype(int)
     pseudo_vcf.sort_values(by=['order', VCFEnums.POS.value], inplace=True)
     pseudo_vcf.drop(columns='order', inplace=True)
@@ -43,7 +61,6 @@ def apply_binarized_label(data: pd.DataFrame) -> None:
             Adds the "binarized_label" column. Which is 0 for LB and B, and 1 for P and LP.
             Please note that this performed inplace.
     """
-    print('Applying binarized label.')
     data[ColumnEnums.BINARIZED_LABEL.value] = np.nan
     data.loc[
         data[data[TrainDataCreatorEnums.CLASS.value].isin(['LB', 'B'])].index,

--- a/tests/capice_resources/train_data_creator/data_parsers/test_clinvar_parser.py
+++ b/tests/capice_resources/train_data_creator/data_parsers/test_clinvar_parser.py
@@ -113,6 +113,20 @@ class TestClinvarParser(unittest.TestCase):
         self.assertEqual('Found unknown review status: some_other_value', str(w.warning))
         self.assertEqual(test_case.shape[0], 0)
 
+    def test_unsupported_contig(self):
+        test_case = pd.concat([pd.DataFrame(
+            {
+                '#CHROM': ['1', 'MT', 'FOOBAR'],
+                'POS': [1, 2, 3],
+                'REF': ['A', 'C', 'G'],
+                'ALT': ['T', 'G', 'C']
+            }
+        ), self.specific_testing_frame], axis=1)
+        with self.assertWarns(UserWarning) as c:
+            observed = self.parser.parse(test_case)
+        self.assertNotIn('FOOBAR', list(observed['#CHROM'].values))
+        self.assertEqual('Removing unsupported contig for 1 variant(s).', str(c.warning))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/capice_resources/train_data_creator/data_parsers/test_vkgl_parser.py
+++ b/tests/capice_resources/train_data_creator/data_parsers/test_vkgl_parser.py
@@ -93,6 +93,23 @@ class TestVKGLParser(unittest.TestCase):
             [1, 2, 2, 2]
         )
 
+    def test_unsupported_contig(self):
+        test_case = pd.DataFrame(
+            {
+                'chromosome': ['1', 'MT', 'FOOBAR'],
+                'start': [100, 200, 300],
+                'ref': ['A', 'C', 'G'],
+                'alt': ['T', 'G', 'C'],
+                'gene': ['foo', 'bar', 'baz'],
+                'classification': ['LB', 'LP', 'P'],
+                'support': ['4 labs', '3 labs', '2 labs']
+            }
+        )
+        with self.assertWarns(UserWarning) as c:
+            observed = self.parser.parse(test_case)
+        self.assertNotIn('FOOBAR', list(observed['#CHROM'].values))
+        self.assertEqual('Removing unsupported contig for 1 variant(s).', str(c.warning))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/capice_resources/train_data_creator/test_utilities.py
+++ b/tests/capice_resources/train_data_creator/test_utilities.py
@@ -45,18 +45,6 @@ class TestUtilities(unittest.TestCase):
             [0, 1, 1, 0]
         )
 
-    def test_unsupported_contig(self):
-        test_case = pd.DataFrame(
-            {
-                '#CHROM': [1, 'MT', 5, 3, 3, 'Y', 'X', 'FOOBAR'],
-                'POS': [100, 200, 300, 500, 400, 1000, 12000, 100]
-            }
-        )
-        with self.assertWarns(UserWarning) as context:
-            correct_order_vcf_notation(test_case)
-        self.assertNotIn('FOOBAR', list(test_case['#CHROM']))
-        self.assertEqual('Removing unsupported contig for 1 variant(s).', str(context.warning))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/capice_resources/train_data_creator/test_utilities.py
+++ b/tests/capice_resources/train_data_creator/test_utilities.py
@@ -1,4 +1,6 @@
 import unittest
+from io import StringIO
+from unittest.mock import patch
 
 import pandas as pd
 
@@ -44,6 +46,18 @@ class TestUtilities(unittest.TestCase):
             list(test_case['binarized_label'].values),
             [0, 1, 1, 0]
         )
+
+    def test_unsupported_contig(self):
+        test_case = pd.DataFrame(
+            {
+                '#CHROM': [1, 'MT', 5, 3, 3, 'Y', 'X', 'FOOBAR'],
+                'POS': [100, 200, 300, 500, 400, 1000, 12000, 100]
+            }
+        )
+        with self.assertWarns(UserWarning) as context:
+            correct_order_vcf_notation(test_case)
+        self.assertNotIn('FOOBAR', list(test_case['#CHROM']))
+        self.assertEqual('Removing unsupported contig for 1 variant(s).', str(context.warning))
 
 
 if __name__ == '__main__':

--- a/tests/capice_resources/train_data_creator/test_utilities.py
+++ b/tests/capice_resources/train_data_creator/test_utilities.py
@@ -1,6 +1,4 @@
 import unittest
-from io import StringIO
-from unittest.mock import patch
 
 import pandas as pd
 


### PR DESCRIPTION
## SOP

### Changed

- Fixed a bug that would crash train-data-creator when supplied with any contig other than 1-22, X, Y or MT.

## Important notes

- Closes #68 

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
