### PR TITLE
Fix/python3.11 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'pandas==1.5.3',
         'numpy==1.24.1',
-        'matplotlib==3.5.1',
+        'matplotlib==3.7.1',
         'scikit-learn==1.2.1',
         'graphviz==0.19.1',
         'seaborn==0.12.1'

--- a/src/molgenis/capice_resources/compare_model_performance/plotter.py
+++ b/src/molgenis/capice_resources/compare_model_performance/plotter.py
@@ -184,7 +184,11 @@ class Plotter:
         figure.suptitle(
             f'Model 1 vs Model 2 {figure_supertitle}'
         )
-        figure.set_constrained_layout(PlottingEnums.CONSTRAINED_LAYOUT.value)
+        figure.set_layout_engine(
+            'constrained',
+            h_pad=PlottingEnums.CONSTRAINED_LAYOUT_H_PAD.value,
+            w_pad=PlottingEnums.CONSTRAINED_LAYOUT_W_PAD.value
+        )
 
     def _set_nrows_and_ncols(self) -> None:
         """

--- a/src/molgenis/capice_resources/core/__init__.py
+++ b/src/molgenis/capice_resources/core/__init__.py
@@ -263,7 +263,8 @@ class ColumnEnums(Enum):
 
 
 class PlottingEnums(Enum):
-    CONSTRAINED_LAYOUT = {'w_pad': 0.2, 'h_pad': 0.2}
+    CONSTRAINED_LAYOUT_W_PAD = 0.2
+    CONSTRAINED_LAYOUT_H_PAD = 0.2
     DPI = 100
 
 

--- a/src/molgenis/capice_resources/threshold_calculator/plotter.py
+++ b/src/molgenis/capice_resources/threshold_calculator/plotter.py
@@ -24,7 +24,11 @@ class ThresholdPlotter:
         self.figure = plt.figure()
         # Retina displays overwrite DPI after initialization
         self.figure.set_dpi(PlottingEnums.DPI.value)
-        self.figure.set_constrained_layout(PlottingEnums.CONSTRAINED_LAYOUT.value)
+        self.figure.set_layout_engine(
+            'constrained',
+            h_pad=PlottingEnums.CONSTRAINED_LAYOUT_H_PAD.value,
+            w_pad=PlottingEnums.CONSTRAINED_LAYOUT_W_PAD.value
+        )
 
     def plot_threshold(self, validation_score_data: pd.DataFrame) -> plt.Figure:
         """


### PR DESCRIPTION
## SOP

### Changed

- Updated Matplotlib to 3.7.1 due to an installment fail for matplotlib 3.5.1 with python3.11.
- Changed the use of deprecated `figure.set_constrained_layout(h_pad=None, w_pad=None)` to `figure.set_layout_engine('constrained', h_pad=None, w_pad=None)`.

## Important notes

- Closes #69 (nice)

### Before merge:
- [ ] Functionality works & meets specs
- [x] No Travis issues
- [x] Code reviewed
- [n.a.] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
